### PR TITLE
Static and dynamic versions of heatshrink aren't compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test_heatshrink_static
 *.o
 *.core
 *.dSYM
+*.exe

--- a/heatshrink.c
+++ b/heatshrink.c
@@ -5,7 +5,6 @@
 #include <stdint.h>
 #include <assert.h>
 #include <string.h>
-#include <err.h>
 #include <fcntl.h>
 
 #include "heatshrink_encoder.h"
@@ -20,6 +19,18 @@
 #define LOG(...) fprintf(stderr, __VA_ARGS__)
 #else
 #define LOG(...) /* NO-OP */
+#endif
+
+#if _WIN32
+#include <errno.h>
+#define HEATSHRINK_ERR(retval, ...) do { \
+fprintf(stderr, __VA_ARGS__); \
+fprintf(stderr, "Undefined error: %d\n", errno); \
+exit(retval); \
+} while(0)
+#else
+#include <err.h>
+#define HEATSHRINK_ERR(...) err(__VA_ARGS__)
 #endif
 
 static const int version_major = HEATSHRINK_VERSION_MAJOR;
@@ -93,7 +104,7 @@ static io_handle *handle_open(char *fname, IO_mode m, size_t buf_sz) {
 
     if (io->fd == -1) {         /* failed to open */
         free(io);
-        err(1, "open");
+        HEATSHRINK_ERR(1, "open");
         return NULL;
     }
 
@@ -125,10 +136,10 @@ static size_t handle_read(io_handle *io, size_t size, uint8_t **buf) {
         io->fill -= io->read;
         io->read = 0;
         ssize_t read_sz = read(io->fd, &io->buf[io->fill], io->size - io->fill);
-        if (read_sz < 0) err(1, "read");
+        if (read_sz < 0) HEATSHRINK_ERR(1, "read");
         io->total += read_sz;
         if (read_sz == 0) {     /* EOF */
-            if (close(io->fd) < 0) err(1, "close");
+            if (close(io->fd) < 0) HEATSHRINK_ERR(1, "close");
             io->fd = -1;
         }
         io->fill += read_sz;
@@ -163,7 +174,7 @@ static ssize_t handle_sink(io_handle *io, size_t size, uint8_t *input) {
         size_t written = write(io->fd, io->buf, io->fill);
         LOG("@ flushing %zd, wrote %zd\n", io->fill, written);
         io->total += written;
-        if (written == -1) err(1, "write");
+        if (written == -1) HEATSHRINK_ERR(1, "write");
         memmove(io->buf, &io->buf[written], io->fill - written);
         io->fill -= written;
     }
@@ -178,7 +189,7 @@ static void handle_close(io_handle *io) {
             size_t written = write(io->fd, io->buf, io->fill);
             io->total += written;
             LOG("@ close: flushing %zd, wrote %zd\n", io->fill, written);
-            if (written == -1) err(1, "write");
+            if (written == -1) HEATSHRINK_ERR(1, "write");
         }
         close(io->fd);
         io->fd = -1;
@@ -252,7 +263,7 @@ static int encode(config *cfg) {
         if (handle_drop(in, read_sz) < 0) die("drop");
     };
 
-    if (read_sz == -1) err(1, "read");
+    if (read_sz == -1) HEATSHRINK_ERR(1, "read");
 
     heatshrink_encoder_free(hse);
     close_and_report(cfg);
@@ -329,7 +340,7 @@ static int decode(config *cfg) {
             if (handle_drop(in, read_sz) < 0) die("drop");
         }
     }
-    if (read_sz == -1) err(1, "read");
+    if (read_sz == -1) HEATSHRINK_ERR(1, "read");
         
     heatshrink_decoder_free(hsd);
     close_and_report(cfg);

--- a/heatshrink.c
+++ b/heatshrink.c
@@ -21,7 +21,7 @@
 #define LOG(...) /* NO-OP */
 #endif
 
-#if _WIN32
+#if _WIN32 || __MICROBLAZE__
 #include <errno.h>
 #define HEATSHRINK_ERR(retval, ...) do { \
 fprintf(stderr, __VA_ARGS__); \

--- a/heatshrink.c
+++ b/heatshrink.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <getopt.h>
 #include <stdint.h>
 #include <assert.h>
 #include <string.h>

--- a/heatshrink.c
+++ b/heatshrink.c
@@ -10,9 +10,15 @@
 #include "heatshrink_encoder.h"
 #include "heatshrink_decoder.h"
 
+#if HEATSHRINK_DYNAMIC_ALLOC
 #define DEF_WINDOW_SZ2 11
 #define DEF_LOOKAHEAD_SZ2 4
 #define DEF_DECODER_INPUT_BUFFER_SIZE 256
+#else
+#define DEF_WINDOW_SZ2 HEATSHRINK_STATIC_WINDOW_BITS
+#define DEF_LOOKAHEAD_SZ2 HEATSHRINK_STATIC_LOOKAHEAD_BITS
+#define DEF_DECODER_INPUT_BUFFER_SIZE HEATSHRINK_STATIC_INPUT_BUFFER_SIZE
+#endif
 #define DEF_BUFFER_SIZE (64 * 1024)
 
 #if 0
@@ -397,6 +403,7 @@ static void proc_args(config *cfg, int argc, char **argv) {
             cfg->cmd = OP_ENC; break;
         case 'd':               /* decode */
             cfg->cmd = OP_DEC; break;
+#if HEATSHRINK_DYNAMIC_ALLOC
         case 'i':               /* input buffer size */
             cfg->decoder_input_buffer_size = atoi(optarg);
             break;
@@ -406,6 +413,13 @@ static void proc_args(config *cfg, int argc, char **argv) {
         case 'l':               /* lookahead bits */
             cfg->lookahead_sz2 = atoi(optarg);
             break;
+#else
+        case 'i':
+        case 'w':
+        case 'l':
+            printf("parameter %c ignored\n", a);
+            break;
+#endif
         case 'v':               /* verbosity++ */
             cfg->verbose++;
             break;

--- a/heatshrink.c
+++ b/heatshrink.c
@@ -92,13 +92,21 @@ static io_handle *handle_open(char *fname, IO_mode m, size_t buf_sz) {
         if (0 == strcmp("-", fname)) {
             io->fd = STDIN_FILENO;
         } else {
-            io->fd = open(fname, O_RDONLY);
+            int oflags = O_RDONLY;
+#if _WIN32
+            oflags |= O_BINARY;
+#endif
+            io->fd = open(fname, oflags);
         }
     } else if (m == IO_WRITE) {
         if (0 == strcmp("-", fname)) {
             io->fd = STDOUT_FILENO;
         } else {
-            io->fd = open(fname, O_WRONLY | O_CREAT | O_TRUNC /*| O_EXCL*/, 0644);
+            int oflags = O_WRONLY | O_CREAT | O_TRUNC /*| O_EXCL*/;
+#if _WIN32
+            oflags |= O_BINARY;
+#endif
+            io->fd = open(fname, oflags, 0644);
         }
     }
 


### PR DESCRIPTION
The static and dynamic versions of heatshrink don't create the same output.

1. I had to fix some compilation issues c.f. https://github.com/sjaeckel/heatshrink/tree/fix/static
  * Now both test targets and heatshrink compile fine. Tests pass.
2. To reproduce that the created files from static and dynamic versions are not the same:
  1. Build heatshrink in default (dynamic) configuration and compress a file with parameters "-i 32 -w 8", the default settings of the static configuration.
  2. Build heatshrink with `HEATSHRINK_DYNAMIC_ALLOC 0` and compress the same file.

Resulting files won't be the same!
Is this intentional?