### PR TITLE
Make heatshrink compile with std=c99 and using getopt().

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ PROJECT = heatshrink
 #OPTIMIZE = -Os
 OPTIMIZE = -O3
 WARN = -Wall -Wextra -pedantic #-Werror
-CFLAGS += -std=c99 -g ${WARN} ${OPTIMIZE}
+CDEFS = -D_POSIX_C_SOURCE=2 -D_C99_SOURCE=1
+CFLAGS += -std=c99 -g ${WARN} ${CDEFS} ${OPTIMIZE}
 CFLAGS += -Wmissing-prototypes
 CFLAGS += -Wstrict-prototypes
 CFLAGS += -Wmissing-declarations

--- a/heatshrink.c
+++ b/heatshrink.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <getopt.h>
 #include <stdint.h>
 #include <assert.h>
 #include <string.h>

--- a/heatshrink.c
+++ b/heatshrink.c
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
-#include <getopt.h>
 #include <stdint.h>
 #include <assert.h>
 #include <string.h>


### PR DESCRIPTION
The current target 'make heatshrink' results in "warning: implicit declaration of function ‘getopt’" and undeclared variable errors.
The -std=c99 prevents <unistd.h> from including <getopt.h> which makes the compile fail.

Including getopt.h additionally resolves this issue (as -std=gnu99 or -D_GNU_SOURCE is not a nice option).