### PR TITLE
Fix a number of Windows-specific issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test_heatshrink_static
 *.o
 *.core
 *.dSYM
+*.exe

--- a/heatshrink.c
+++ b/heatshrink.c
@@ -154,7 +154,7 @@ static ssize_t handle_read(io_handle *io, size_t size, uint8_t **buf) {
     LOG("@ read %zd\n", size);
     if (buf == NULL) { return -1; }
     if (size > io->size) {
-        printf("size %zd, io->size %zd\n", size, io->size);
+        fprintf(stderr, "size %zd, io->size %zd\n", size, io->size);
         return -1;
     }
     if (io->mode != IO_READ) { return -1; }
@@ -289,7 +289,7 @@ static int encode(config *cfg) {
         uint8_t *input = NULL;
         read_sz = handle_read(in, window_sz, &input);
         if (input == NULL) {
-            printf("handle read failure\n");
+            fprintf(stderr, "handle read failure\n");
             die("read");
         }
         if (read_sz < 0) { die("read"); }
@@ -363,7 +363,7 @@ static int decode(config *cfg) {
         uint8_t *input = NULL;
         read_sz = handle_read(in, window_sz, &input);
         if (input == NULL) {
-            printf("handle read failure\n");
+            fprintf(stderr, "handle read failure\n");
             die("read");
         }
         if (read_sz == 0) {
@@ -446,7 +446,7 @@ int main(int argc, char **argv) {
 
     if (0 == strcmp(cfg.in_fname, cfg.out_fname)
         && (0 != strcmp("-", cfg.in_fname))) {
-        printf("Refusing to overwrite file '%s' with itself.\n", cfg.in_fname);
+        fprintf(stderr, "Refusing to overwrite file '%s' with itself.\n", cfg.in_fname);
         exit(1);
     }
 

--- a/heatshrink.c
+++ b/heatshrink.c
@@ -32,6 +32,14 @@ exit(retval); \
 #define HEATSHRINK_ERR(...) err(__VA_ARGS__)
 #endif
 
+/*
+ * We have to open binary files with the O_BINARY flag on Windows. Most other
+ * platforms don't differentiate between binary and non-binary files.
+ */
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
 static const int version_major = HEATSHRINK_VERSION_MAJOR;
 static const int version_minor = HEATSHRINK_VERSION_MINOR;
 static const int version_patch = HEATSHRINK_VERSION_PATCH;
@@ -121,13 +129,13 @@ static io_handle *handle_open(char *fname, IO_mode m, size_t buf_sz) {
         if (0 == strcmp("-", fname)) {
             io->fd = STDIN_FILENO;
         } else {
-            io->fd = open(fname, O_RDONLY);
+            io->fd = open(fname, O_RDONLY | O_BINARY);
         }
     } else if (m == IO_WRITE) {
         if (0 == strcmp("-", fname)) {
             io->fd = STDOUT_FILENO;
         } else {
-            io->fd = open(fname, O_WRONLY | O_CREAT | O_TRUNC /*| O_EXCL*/, 0644);
+            io->fd = open(fname, O_WRONLY | O_BINARY | O_CREAT | O_TRUNC /*| O_EXCL*/, 0644);
         }
     }
 

--- a/heatshrink.c
+++ b/heatshrink.c
@@ -455,6 +455,15 @@ int main(int argc, char **argv) {
     cfg.out = handle_open(cfg.out_fname, IO_WRITE, cfg.buffer_size);
     if (cfg.out == NULL) { die("Failed to open output file for write"); }
 
+#if _WIN32
+    /*
+     * On Windows, stdin and stdout default to text mode. Switch them to
+     * binary mode before sending data through them.
+     */
+    _setmode(STDOUT_FILENO, O_BINARY);
+    _setmode(STDIN_FILENO, O_BINARY);
+#endif
+
     if (cfg.cmd == OP_ENC) {
         return encode(&cfg);
     } else if (cfg.cmd == OP_DEC) {


### PR DESCRIPTION
These commits fix a number of Windows-specific issues in Heatshrink, as noted on #9. They port most of sjaeckel's changes from PR #4 to the latest version of Heatshrink, with the exception of the Microblaze changes which I cannot test.

Most of these fixes are related to Windows' special handling of text and binary mode data streams, and the data corruption and truncation you get when sending binary data down a stream open in text mode.

There is also one fix (4d94f2d) which is likely to be useful on other platforms; this ensures that error messages are sent out on the stderr stream. There is one potential unresolved issue with this fix: on line 390 of heatshrink.c, function report(), there is an fprintf() which will output on stderr if data is being piped, or stdout if it is being sent to a file. I'd argue that this should always send to stderr.