### PR TITLE
Encoder states

### DIFF
--- a/enc_sm.dot
+++ b/enc_sm.dot
@@ -26,13 +26,10 @@ digraph {
 
         yield_tag_bit->yield_tag_bit [label="poll(), full buf", color="red"]
         yield_tag_bit->yield_literal [label="poll(), literal", color="red"]
-        yield_tag_bit->yield_br_index [label="poll(), no literal", color="red"]
-        yield_tag_bit->flush_bits [label="finishing, no literal"]
+        yield_tag_bit->yield_br_index [label="poll(), match", color="red"]
 
         yield_literal->yield_literal [label="poll(), full buf", color="red"]
-        yield_literal->search [label="poll(), no match", color="red"]
-        yield_literal->yield_tag_bit [label="poll(), match", color="red"]
-        yield_literal->flush_bits [label="poll(), final literal", color="red"]
+        yield_literal->search [label="done"]
 
         yield_br_index->yield_br_index [label="poll(), full buf", color="red"]
         yield_br_index->yield_br_length [label="poll()", color="red"]
@@ -40,8 +37,7 @@ digraph {
         yield_br_length->yield_br_length [label="poll(), full buf", color="red"]
         yield_br_length->search [label="done"]
 
-        save_backlog->flush_bits [label="finishing, no literal"]
-        save_backlog->yield_tag_bit [label="finishing, literal"]
+        save_backlog->flush_bits [label="finishing"]
         save_backlog->not_full [label="expect more input"]
 
         flush_bits->flush_bits [label="poll(), full buf", color="red"]

--- a/enc_sm.dot
+++ b/enc_sm.dot
@@ -20,7 +20,6 @@ digraph {
 
         filled->search [label="indexing (if any)"]
 
-        search->search [label="step"]
         search->yield_tag_bit [label="literal"]
         search->yield_tag_bit [label="match found"]
         search->save_backlog [label="input exhausted"]

--- a/enc_sm.dot
+++ b/enc_sm.dot
@@ -22,7 +22,8 @@ digraph {
 
         search->yield_tag_bit [label="literal"]
         search->yield_tag_bit [label="match found"]
-        search->save_backlog [label="input exhausted"]
+        search->save_backlog [label="input exhausted, not finishing"]
+        search->flush_bits [label="input exhausted, finishing"]
 
         yield_tag_bit->yield_tag_bit [label="poll(), full buf", color="red"]
         yield_tag_bit->yield_literal [label="poll(), literal", color="red"]
@@ -37,7 +38,6 @@ digraph {
         yield_br_length->yield_br_length [label="poll(), full buf", color="red"]
         yield_br_length->search [label="done"]
 
-        save_backlog->flush_bits [label="finishing"]
         save_backlog->not_full [label="expect more input"]
 
         flush_bits->flush_bits [label="poll(), full buf", color="red"]

--- a/heatshrink_encoder.c
+++ b/heatshrink_encoder.c
@@ -42,10 +42,8 @@ static const char *state_names[] = {
 // Encoder flags
 enum {
     FLAG_IS_FINISHING = 0x01,
-    FLAG_HAS_LITERAL = 0x02,
-    FLAG_ON_FINAL_LITERAL = 0x04,
-    FLAG_BACKLOG_IS_PARTIAL = 0x08,
-    FLAG_BACKLOG_IS_FILLED = 0x10,
+    FLAG_BACKLOG_IS_PARTIAL = 0x02,
+    FLAG_BACKLOG_IS_FILLED = 0x04,
 };
 
 typedef struct {
@@ -64,9 +62,7 @@ static int can_take_byte(output_info *oi);
 static int is_finishing(heatshrink_encoder *hse);
 static int backlog_is_partial(heatshrink_encoder *hse);
 static int backlog_is_filled(heatshrink_encoder *hse);
-static int on_final_literal(heatshrink_encoder *hse);
 static void save_backlog(heatshrink_encoder *hse);
-static int has_literal(heatshrink_encoder *hse);
 
 /* Push COUNT (max 8) bits to the output buffer, which has room. */
 static void push_bits(heatshrink_encoder *hse, uint8_t count, uint8_t bits,
@@ -305,7 +301,6 @@ static HSE_state st_step_search(heatshrink_encoder *hse) {
     if (match_pos == MATCH_NOT_FOUND) {
         LOG("ss Match not found\n");
         hse->match_scan_index++;
-        hse->flags |= FLAG_HAS_LITERAL;
         hse->match_length = 0;
         return HSES_YIELD_TAG_BIT;
     } else {
@@ -339,9 +334,7 @@ static HSE_state st_yield_literal(heatshrink_encoder *hse,
         output_info *oi) {
     if (can_take_byte(oi)) {
         push_literal_byte(hse, oi);
-        hse->flags &= ~FLAG_HAS_LITERAL;
-        if (on_final_literal(hse)) { return HSES_FLUSH_BITS; }
-        return hse->match_length > 0 ? HSES_YIELD_TAG_BIT : HSES_SEARCH;
+        return HSES_SEARCH;
     } else {
         return HSES_YIELD_LITERAL;
     }
@@ -381,13 +374,7 @@ static HSE_state st_yield_br_length(heatshrink_encoder *hse,
 
 static HSE_state st_save_backlog(heatshrink_encoder *hse) {
     if (is_finishing(hse)) {
-        /* copy remaining literal (if necessary) */
-        if (has_literal(hse)) {
-            hse->flags |= FLAG_ON_FINAL_LITERAL;
-            return HSES_YIELD_TAG_BIT;
-        } else {
-            return HSES_FLUSH_BITS;
-        }
+        return HSES_FLUSH_BITS;
     } else {
         LOG("-- saving backlog\n");
         save_backlog(hse);
@@ -478,14 +465,6 @@ static int backlog_is_partial(heatshrink_encoder *hse) {
 
 static int backlog_is_filled(heatshrink_encoder *hse) {
     return hse->flags & FLAG_BACKLOG_IS_FILLED;
-}
-
-static int on_final_literal(heatshrink_encoder *hse) {
-    return hse->flags & FLAG_ON_FINAL_LITERAL;
-}
-
-static int has_literal(heatshrink_encoder *hse) {
-    return (hse->flags & FLAG_HAS_LITERAL);
 }
 
 static int can_take_byte(output_info *oi) {

--- a/heatshrink_encoder.c
+++ b/heatshrink_encoder.c
@@ -272,8 +272,8 @@ static HSE_state st_step_search(heatshrink_encoder *hse) {
     if (msi >= hse->input_size - (fin ? 0 : lookahead_sz)) {
         /* Current search buffer is exhausted, copy it into the
          * backlog and await more input. */
-        LOG("-- end of search @ %d, saving backlog\n", msi);
-        return HSES_SAVE_BACKLOG;
+        LOG("-- end of search @ %d\n", msi);
+        return fin ? HSES_FLUSH_BITS : HSES_SAVE_BACKLOG;
     }
 
     uint16_t input_offset = get_input_offset(hse);
@@ -373,13 +373,9 @@ static HSE_state st_yield_br_length(heatshrink_encoder *hse,
 }
 
 static HSE_state st_save_backlog(heatshrink_encoder *hse) {
-    if (is_finishing(hse)) {
-        return HSES_FLUSH_BITS;
-    } else {
-        LOG("-- saving backlog\n");
-        save_backlog(hse);
-        return HSES_NOT_FULL;
-    }
+    LOG("-- saving backlog\n");
+    save_backlog(hse);
+    return HSES_NOT_FULL;
 }
 
 static HSE_state st_flush_bit_buffer(heatshrink_encoder *hse,


### PR DESCRIPTION
The encoder state machine has some unreachable states (leftovers from older revisions?) involving the flag ```FLAG_ON_FINAL_LITERAL```.  After removing those, ```FLAG_HAS_LITERAL``` is no longer used.  Additionally, the penultimate pair of state transitions ```search``` → ```save_backlog``` → ```flush_bits``` can be optimized.