### PR TITLE
Fix match window start

### DIFF
--- a/heatshrink_encoder.c
+++ b/heatshrink_encoder.c
@@ -274,7 +274,7 @@ static HSE_state st_step_search(heatshrink_encoder *hse) {
 
     uint16_t input_offset = get_input_offset(hse);
     uint16_t end = input_offset + msi;
-    uint16_t start = end - window_length;
+    uint16_t start = end - window_length + 1;
 
     uint16_t max_possible = lookahead_sz;
     if (hse->input_size - msi < lookahead_sz) {


### PR DESCRIPTION
Start is computed as `end - window_size`, which means a match with offset `window_size` is possible.

To reproduce the error, create a 2048 byte file where that last few bytes are unique, and concatenate it with itself. Compress with heatshrink command-line tool, and it will find a match with offset 2048.

This should fix #36.
