### PR TITLE
Fixed fallthrough compiler warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ heatshrink
 test_heatshrink_dynamic
 test_heatshrink_static
 *.o
+*.od
+*.os
+*.a
 *.core
 *.dSYM
 *.exe

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2015, Scott Vokes <scott.vokes@atomicobject.com>
+Copyright (c) 2013-2015, Scott Vokes <vokes.s@gmail.com>
 All rights reserved.
  
 Permission to use, copy, modify, and/or distribute this software for any

--- a/Makefile
+++ b/Makefile
@@ -66,12 +66,20 @@ RM ?=		rm
 
 install: libraries heatshrink
 	${INSTALL} -c heatshrink ${PREFIX}/bin/
-	${INSTALL} -c libheatshrink_{static,dynamic}.a ${PREFIX}/lib/
-	${INSTALL} -c heatshrink_{common,config,decoder,encoder}.h ${PREFIX}/include/
+	${INSTALL} -c libheatshrink_static.a ${PREFIX}/lib/
+	${INSTALL} -c libheatshrink_dynamic.a ${PREFIX}/lib/
+	${INSTALL} -c heatshrink_common.h ${PREFIX}/include/
+	${INSTALL} -c heatshrink_config.h ${PREFIX}/include/
+	${INSTALL} -c heatshrink_encoder.h ${PREFIX}/include/
+	${INSTALL} -c heatshrink_decoder.h ${PREFIX}/include/
 
 uninstall:
-	${RM} -f ${PREFIX}/lib/libheatshrink_{static,dynamic}.a
-	${RM} -f ${PREFIX}/include/heatshrink_{common,config,decoder,encoder}.h
+	${RM} -f ${PREFIX}/lib/libheatshrink_static.a
+	${RM} -f ${PREFIX}/lib/libheatshrink_dynamic.a
+	${RM} -f ${PREFIX}/include/heatshrink_common.h
+	${RM} -f ${PREFIX}/include/heatshrink_config.h
+	${RM} -f ${PREFIX}/include/heatshrink_encoder.h
+	${RM} -f ${PREFIX}/include/heatshrink_decoder.h
 
 # Internal targets and rules
 

--- a/heatshrink.c
+++ b/heatshrink.c
@@ -409,6 +409,7 @@ static void proc_args(config *cfg, int argc, char **argv) {
         switch (a) {
         case 'h':               /* help */
             usage();
+            break;
         case 'e':               /* encode */
             cfg->cmd = OP_ENC; break;
         case 'd':               /* decode */

--- a/heatshrink.c
+++ b/heatshrink.c
@@ -409,7 +409,7 @@ static void proc_args(config *cfg, int argc, char **argv) {
         switch (a) {
         case 'h':               /* help */
             usage();
-            break;
+            /* FALLTHROUGH */
         case 'e':               /* encode */
             cfg->cmd = OP_ENC; break;
         case 'd':               /* decode */

--- a/heatshrink_common.h
+++ b/heatshrink_common.h
@@ -1,7 +1,7 @@
 #ifndef HEATSHRINK_H
 #define HEATSHRINK_H
 
-#define HEATSHRINK_AUTHOR "Scott Vokes <scott.vokes@atomicobject.com>"
+#define HEATSHRINK_AUTHOR "Scott Vokes <vokes.s@gmail.com>"
 #define HEATSHRINK_URL "https://github.com/atomicobject/heatshrink"
 
 /* Version 0.4.1 */

--- a/heatshrink_common.h
+++ b/heatshrink_common.h
@@ -4,10 +4,10 @@
 #define HEATSHRINK_AUTHOR "Scott Vokes <scott.vokes@atomicobject.com>"
 #define HEATSHRINK_URL "https://github.com/atomicobject/heatshrink"
 
-/* Version 0.4.0 */
+/* Version 0.4.1 */
 #define HEATSHRINK_VERSION_MAJOR 0
 #define HEATSHRINK_VERSION_MINOR 4
-#define HEATSHRINK_VERSION_PATCH 0
+#define HEATSHRINK_VERSION_PATCH 1
 
 #define HEATSHRINK_MIN_WINDOW_BITS 4
 #define HEATSHRINK_MAX_WINDOW_BITS 15

--- a/heatshrink_encoder.c
+++ b/heatshrink_encoder.c
@@ -235,6 +235,7 @@ HSE_poll_res heatshrink_encoder_poll(heatshrink_encoder *hse,
             break;
         case HSES_FLUSH_BITS:
             hse->state = st_flush_bit_buffer(hse, &oi);
+            return HSER_POLL_EMPTY;
         case HSES_DONE:
             return HSER_POLL_EMPTY;
         default:


### PR DESCRIPTION
Fixed fallthrough warnings thrown in GCC 7.1.1:

```
heatshrink_encoder.c: In function ‘heatshrink_encoder_poll’:
heatshrink_encoder.c:237:24: warning: this statement may fall through [-Wimplicit-fallthrough=]
             hse->state = st_flush_bit_buffer(hse, &oi);
             ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
heatshrink_encoder.c:238:9: note: here
         case HSES_DONE:


heatshrink.c: In function ‘proc_args’:
heatshrink.c:411:13: warning: this statement may fall through [-Wimplicit-fallthrough=]
             usage();
             ^~~~~~~
heatshrink.c:412:9: note: here
         case 'e':               /* encode */

```