### PR TITLE
Add option to override heatshrink configuration

### DIFF
--- a/src/heatshrink_config.h
+++ b/src/heatshrink_config.h
@@ -12,15 +12,27 @@
     #define HEATSHRINK_FREE(P, SZ) free(P)
 #else
     /* Required parameters for static configuration */
+    #ifndef HEATSHRINK_STATIC_INPUT_BUFFER_SIZE
     #define HEATSHRINK_STATIC_INPUT_BUFFER_SIZE 32
+    #endif
+
+    #ifndef HEATSHRINK_STATIC_WINDOW_BITS
     #define HEATSHRINK_STATIC_WINDOW_BITS 8
+    #endif
+
+    #ifndef HEATSHRINK_STATIC_LOOKAHEAD_BITS
     #define HEATSHRINK_STATIC_LOOKAHEAD_BITS 4
+    #endif
 #endif
 
 /* Turn on logging for debugging. */
+#ifndef HEATSHRINK_DEBUGGING_LOGS
 #define HEATSHRINK_DEBUGGING_LOGS 0
+#endif
 
 /* Use indexing for faster compression. (This requires additional space.) */
+#ifndef HEATSHRINK_USE_INDEX
 #define HEATSHRINK_USE_INDEX 1
+#endif
 
 #endif


### PR DESCRIPTION
Currently its impossible to change heatshrink compression configuration
wihout touching the library header files. This patch makes it possible
for configuration which can be configured at compilation time without
having to touch the library. Which makes it easier to keep it sync with
github source without modifying the actual source.

Signed-off-by: Ajay Bhargav <contact@rickeyworld.info>