### PR TITLE
Fix indexing for platforms where char size is larger than a byte

### DIFF
--- a/heatshrink_encoder.c
+++ b/heatshrink_encoder.c
@@ -419,7 +419,7 @@ static void do_indexing(heatshrink_encoder *hse) {
      * */
     struct hs_index *hsi = HEATSHRINK_ENCODER_INDEX(hse);
     int16_t last[256];
-    memset(last, 0xFF, sizeof(last));
+    memset(last, -1, sizeof(last));
 
     uint8_t * const data = hse->buffer;
     int16_t * const index = hsi->index;


### PR DESCRIPTION
On platforms where the minimum memory access size is larger than a byte (case in point, μ'nSP where each address refers to one 16-bit word rather than a byte), indexing would never work due to the index buffer being initialized improperly. Instead of each element being initialized to `-1` as would typically happen on a system with byte sized access, it gets initialized to `255`. This breaks the indexing logic and causes it to go into an infinite loop.

This patch changes the initializer from `0xff` to `-1`, so depending on the platform it should always initialize the entire array with `-1`. On byte access systems, `memset()` will truncate the `-1` to `0xff` as per standard, which results in the same desired behavior.