### PR TITLE
Fix encoder bug when finishing

### DIFF
--- a/heatshrink_encoder.c
+++ b/heatshrink_encoder.c
@@ -265,7 +265,9 @@ static HSE_state st_step_search(heatshrink_encoder *hse) {
         msi, hse->input_size + msi, 2*window_length, hse->input_size);
 
     bool fin = is_finishing(hse);
-    if (msi > hse->input_size - (fin ? 1 : lookahead_sz)) {
+    if (fin && hse->input_size == 0) {
+        return HSES_FLUSH_BITS;
+    } else if (msi > hse->input_size - (fin ? 1 : lookahead_sz)) {
         /* Current search buffer is exhausted, copy it into the
          * backlog and await more input. */
         LOG("-- end of search @ %d\n", msi);


### PR DESCRIPTION
Via some fuzzing, I found a finish scenario that can result in incorrect encoding. This PR addresses the bug by adding a check for `finishing && input size == 0` in the search step to transition to flush bits.

Explanation:

At finish time, if the `input_size` is 0 then there is no more data to encode and the remaining bits should be flushed. However, because the search step does `input_size - 1` this results in an overflow and the search step transitions to yielding a tag bit instead. I'm not really sure what happens from this point on, but I suspect it may loop infinitely.