### PR TITLE
Fix indexing integer overflow for 15-bit window

### DIFF
--- a/heatshrink_encoder.c
+++ b/heatshrink_encoder.c
@@ -425,9 +425,9 @@ static void do_indexing(heatshrink_encoder *hse) {
     int16_t * const index = hsi->index;
 
     const uint16_t input_offset = get_input_offset(hse);
-    const uint16_t end = input_offset + hse->input_size;
+    const uint16_t end = (input_offset - 1) + hse->input_size;
 
-    for (uint16_t i=0; i<end; i++) {
+    for (uint16_t i=0; i<=end; i++) {
         uint8_t v = data[i];
         int16_t lv = last[v];
         index[i] = lv;


### PR DESCRIPTION
Partly addresses #86

A 15-bit window with a filled input buffer can result in an integer overflow in `do_indexing`. This PR addresses the problem by making the end bound inclusive.

One solution I came up with to actually get indexing to work for a 15-bit window was to make the index an unsigned 16-bit integer array with 0xFFFF representing end-of-list.